### PR TITLE
Register email

### DIFF
--- a/src/api/forgotPassword.js
+++ b/src/api/forgotPassword.js
@@ -1,9 +1,10 @@
 const router = require("express").Router();
-const nodemailer = require("nodemailer");
 const User = require("../models/User");
 const { sendResponse } = require("./../utils/sendResponse");
 const { isGmailEnabled } = require("../utils/getConfigFile");
 const { sendMail } = require("../utils/sendMail");
+const { generateAndCommitPIN } = require("../utils/pinHelpers");
+
 router.post("/forgotPassword", async function(req, res) {
   const usingGmail = await isGmailEnabled();
   if (!usingGmail) {
@@ -29,14 +30,7 @@ router.post("/forgotPassword", async function(req, res) {
     req.body.answer &&
     user.answer === req.body.answer.toLowerCase().replace(/\s/g, "")
   ) {
-    //user found, update pin
-    user.pin = Math.floor(Math.random() * (100000000 - 100000 + 1)) + 100000;
-    var date = new Date();
-    // add a day to the current date
-    date.setDate(date.getDate() + 1);
-    user.expiration = date;
-    await user.save();
-
+    generateAndCommitPIN(user);
     const body = {
       from: "hack4impact.infra@gmail.com",
       to: user.email,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -8,6 +8,7 @@ router.use("/", require("./forgotPassword"));
 router.use("/", require("./changePassword"));
 router.use("/", require("./google"));
 router.use("/", require("./addSecurityQuestion"));
+router.use("/", require("./verifyEmail"));
 router.use("/", require("./roles"));
 router.use("/", require("./rolesChange"));
 router.use("/", require("./verify"));

--- a/src/api/passwordReset.js
+++ b/src/api/passwordReset.js
@@ -4,6 +4,7 @@ const User = require("../models/User");
 const { sendResponse } = require("./../utils/sendResponse");
 const { signAuthJWT } = require("../utils/jwtHelpers");
 const { isGmailEnabled } = require("../utils/getConfigFile");
+const { expirePIN } = require("../utils/pinHelpers");
 
 router.post("/passwordReset", async function(req, res) {
   const gmailEnabled = await isGmailEnabled();
@@ -46,14 +47,7 @@ router.post("/passwordReset", async function(req, res) {
       return;
     }
   }
-  // user matches, change expiration
-  var date = new Date();
-  // remove a day to the current date to expire it
-  // set date to 24 hours before because we don't want
-  // concurrent requests happening in the same second to both go through
-  // (i.e. if the user presses change password button twice)
-  date.setDate(date.getDate() - 1);
-  user.expiration = date;
+  expirePIN(user);
   user.password = await bcrypt.hash(req.body.password, 10);
   await user.save();
 

--- a/src/api/register.js
+++ b/src/api/register.js
@@ -4,8 +4,10 @@ const User = require("../models/User");
 const { sendResponse } = require("./../utils/sendResponse");
 const { getRolesForUser } = require("./../utils/getConfigFile");
 const { signAuthJWT } = require("../utils/jwtHelpers");
-
+const { generateAndCommitPIN } = require("../utils/pinHelpers");
+const { isGmailEnabled } = require("../utils/getConfigFile");
 router.post("/register", async function(req, res) {
+  const usingGmail = await isGmailEnabled();
   if (!req.body.email || !req.body.password || !req.body.role) {
     return sendResponse(
       res,
@@ -24,7 +26,8 @@ router.post("/register", async function(req, res) {
   const userData = {
     email: req.body.email,
     password: encodedPassword,
-    role: req.body.role
+    role: req.body.role,
+    verified: false
   };
   const user = new User(userData);
   const requiredAuthFrom = await getRolesForUser(req.body.role);
@@ -38,6 +41,29 @@ router.post("/register", async function(req, res) {
   }
 
   const jwt_token = signAuthJWT(user._id, user.password);
+
+  if (usingGmail) {
+    // using gmail so should send verification email
+    generateAndCommitPIN();
+    const body = {
+      from: "hack4impact.infra@gmail.com",
+      to: user.email,
+      subject: "Forgot Password",
+      text: "Enter the following pin on the reset page: " + user.pin
+    };
+    try {
+      await sendMail(body);
+    } catch (e) {
+      // TODO: discuss whether or not we want to register the user even if the email doesn't send
+      return sendResponse(
+        res,
+        500,
+        "Verification email could not be sent despite Gmail being enabled. User not added to DB"
+      );
+    }
+  }
+
+  // success, so save the user to the DB and send back the JWT
   await user.save();
   return res.status(200).send({
     status: 200,

--- a/src/api/verifyEmail.js
+++ b/src/api/verifyEmail.js
@@ -20,10 +20,12 @@ router.post("/verifyEmail", async function(req, res) {
       "Malformed request: email or pin not specified"
     );
   }
-
-  const user = await User.findOne({ email: req.body.email }).catch(e =>
-    console.log(e)
-  );
+  let user;
+  try {
+    user = await User.findOne({ email: req.body.email });
+  } catch (e) {
+    return sendResponse(res, 400, e);
+  }
 
   if (!user) {
     return sendResponse(res, 400, "User does not exist in the DB.");
@@ -33,7 +35,6 @@ router.post("/verifyEmail", async function(req, res) {
   }
 
   if (req.body.pin != user.pin) {
-    console.log(typeof user.pin);
     return sendResponse(res, 400, "PIN does not match");
   }
 

--- a/src/api/verifyEmail.js
+++ b/src/api/verifyEmail.js
@@ -1,0 +1,45 @@
+const router = require("express").Router();
+const User = require("../models/User");
+const { sendResponse } = require("./../utils/sendResponse");
+const { isGmailEnabled } = require("../utils/getConfigFile");
+const { sendMail } = require("../utils/sendMail");
+
+router.post("/verifyEmail", async function(req, res) {
+  const usingGmail = await isGmailEnabled();
+  if (!usingGmail) {
+    return sendResponse(
+      res,
+      500,
+      "Gmail not enabled. Do not use this endpoint."
+    );
+  }
+  if (!req.body || !req.body.email || !req.body.pin) {
+    return sendResponse(
+      res,
+      400,
+      "Malformed request: email or pin not specified"
+    );
+  }
+
+  const user = await User.findOne({ email: req.body.email }).catch(e =>
+    console.log(e)
+  );
+
+  if (!user) {
+    return sendResponse(res, 400, "User does not exist in the DB.");
+  }
+  if (user.verified === 1) {
+    return sendResponse(res, 400, "User has already verified their email");
+  }
+
+  if (req.body.pin != user.pin) {
+    console.log(typeof user.pin);
+    return sendResponse(res, 400, "PIN does not match");
+  }
+
+  user.verified = true;
+  await user.save();
+  return sendResponse(res, 200, "User successfully verified");
+});
+
+module.exports = router;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -7,6 +7,7 @@ const schema = mongoose.Schema({
   question: "string",
   answer: "string",
   pin: "number",
+  verified: "boolean",
   expiration: "date",
   userLevel: "string",
   googleAuth: "boolean",

--- a/src/utils/pinHelpers.js
+++ b/src/utils/pinHelpers.js
@@ -1,0 +1,26 @@
+// Generate and save the pin for the user, returning the generated PIN
+async function generateAndCommitPIN(user) {
+  if (!user) {
+    throw "User is not defined";
+  }
+  // generate and update update pin
+  user.pin = Math.floor(Math.random() * (100000000 - 100000 + 1)) + 100000;
+  var date = new Date();
+  // add a day to the current date for the expiration
+  date.setDate(date.getDate() + 1);
+  user.expiration = date;
+  await user.save();
+  return user.pin;
+}
+async function expirePIN(user) {
+  // user matches, change expiration
+  var date = new Date();
+  // remove a day to the current date to expire it
+  // set date to 24 hours before because we don't want
+  // concurrent requests happening in the same second to both go through
+  // (i.e. if the user presses change password button twice)
+  date.setDate(date.getDate() - 1);
+  user.expiration = date;
+  await user.save();
+}
+module.exports = { generateAndCommitPIN, expirePIN };

--- a/src/utils/sendMail.js
+++ b/src/utils/sendMail.js
@@ -1,0 +1,22 @@
+const nodemailer = require("nodemailer");
+async function sendMail(mail_body) {
+  let transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      type: "OAuth2",
+      user: process.env.INFRA_EMAIL,
+      clientId: process.env.INFRA_CLIENT_ID,
+      clientSecret: process.env.INFRA_CLIENT_SECRET,
+      refreshToken: process.env.INFRA_REFRESH_TOKEN
+    }
+  });
+  await transporter.sendMail(mail_body).catch(_ => {
+    sendResponse(
+      res,
+      500,
+      "An internal server error occured and the email could not be sent."
+    );
+  });
+}
+
+module.exports = { sendMail };

--- a/src/utils/sendMail.js
+++ b/src/utils/sendMail.js
@@ -1,4 +1,5 @@
 const nodemailer = require("nodemailer");
+const { sendResponse } = require("../utils/sendResponse");
 async function sendMail(mail_body) {
   let transporter = nodemailer.createTransport({
     service: "gmail",
@@ -10,13 +11,8 @@ async function sendMail(mail_body) {
       refreshToken: process.env.INFRA_REFRESH_TOKEN
     }
   });
-  await transporter.sendMail(mail_body).catch(_ => {
-    sendResponse(
-      res,
-      500,
-      "An internal server error occured and the email could not be sent."
-    );
-  });
+  var success = true;
+  await transporter.sendMail(mail_body);
 }
 
 module.exports = { sendMail };


### PR DESCRIPTION
Adds the ability to send an email when registering a user, giving them a pin that they can then use to hit the `/verifyEmail` endpoint. DB field now has a verified flag.
Fixes #25 