### PR TITLE
Added basic linting 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 9,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  extends: "eslint:recommended",
+  env: {
+    amd: true,
+    node: true,
+    es6: true
+  },
+  rules: {
+    "no-console": "off"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     }
   },
   "lint-staged": {
+    "*.js": "eslint",
     "*.{js,json,css,md}": [
       "prettier --write",
       "git add"


### PR DESCRIPTION
This is completely a design decision @CodeBrew28 and @HRimaw2 it's your choice if you want to incorporate it - I have a linter set up locally that catches very basic (non style) errors like misspelling and not declaring variable names. Since `now` will not propagate these errors to the user, it's best if we do as much as we can to catch potential bugs before they occur.  But if you don't think having a linter run after each commit is a good idea, that's completely understandable.