### PR TITLE
Removed warnings on yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "docs": "docz dev",
     "test": "mocha"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hack4impact-uiuc/infra-authentication-server.git"
+  },
   "license": "MIT",
   "dependencies": {
     "@sendgrid/mail": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "docs": "docz dev",
     "test": "mocha"
   },
+  "license": "MIT",
   "dependencies": {
     "@sendgrid/mail": "^6.3.1",
     "bcrypt": "3.0.0",
@@ -31,7 +32,10 @@
     "node-pre-gyp": "^0.12.0",
     "nodemailer": "^5.1.1",
     "nodemon": "^1.18.10",
-    "supertest": "^3.4.2"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "supertest": "^3.4.2",
+    "typescript": "^3.4.3"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6985,7 +6985,7 @@ react-docgen@^3.0.0:
     node-dir "^0.1.10"
     recast "^0.16.0"
 
-react-dom@^16.7.0:
+react-dom@^16.7.0, react-dom@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   dependencies:
@@ -7095,7 +7095,7 @@ react-sizes@^1.0.4:
     lodash.throttle "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.7.0:
+react@^16.7.0, react@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   dependencies:
@@ -8474,6 +8474,11 @@ type-is@~1.6.16:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
<img width="335" alt="Screen Shot 2019-04-17 at 3 33 23 PM" src="https://user-images.githubusercontent.com/8664074/56319105-6739bf00-6126-11e9-9e33-a1782846be21.png">

I love not seeing any scary-looking warnings when installing dependencies :) 