### PR TITLE
Better errors if email sending fails

### DIFF
--- a/src/api/register.js
+++ b/src/api/register.js
@@ -75,7 +75,7 @@ router.post(
         return sendResponse(
           res,
           500,
-          "Verification email could not be sent despite Gmail being enabled. User not added to DB"
+          "Verification email could not be sent despite Gmail being enabled. This is likely due to incorrect gmail keys in the .env file. User not added to DB."
         );
       }
     }

--- a/src/api/resendVerificationEmail.js
+++ b/src/api/resendVerificationEmail.js
@@ -53,7 +53,7 @@ router.post(
       return sendResponse(
         res,
         500,
-        "Verification email could not be sent despite Gmail being enabled. User not added to DB"
+        "Verification email could not be sent despite Gmail being enabled. This is likely due to incorrect gmail keys in the .env file. User not added to DB."
       );
     }
   })

--- a/test/register-login-tests.js
+++ b/test/register-login-tests.js
@@ -77,7 +77,11 @@ describe("POST /register", function() {
       .post("/register")
       .type("form")
       .send(valid_register_test);
-    assert.equal(200, response.body.status);
+    assert.equal(
+      200,
+      response.body.status,
+      "Failed with message: " + response.body.message
+    );
     assert.equal("User added successfully!", response.body.message);
     console.log("response.body.message: " + response.body.message);
   }).timeout(5000); // add a longer timeout since there's a lot that has to get done when adding a user


### PR DESCRIPTION
If email fails to send on register, I want it to be clear that the error stems most likely from an invalid `.env` file setup. 